### PR TITLE
fix: handle migration of old versions of throwaway wallet, so it can be reused

### DIFF
--- a/client/src/context/throwaway.tsx
+++ b/client/src/context/throwaway.tsx
@@ -115,6 +115,8 @@ export const ThrowawayProvider = ({ children }: { children: ReactNode }) => {
       // throwaway wallet is stored in local storage in the format of `${connectedAddress}:${privateKey}`
       // connectedAddress is the last connected address that has been used to generate the throwaway wallet
       // if current address and last connected address differ, then there is the need to generate new encrypted throwaway wallet and save to arweave
+      const isOldVersion = localStorage.getItem('throwawayWallet') && !localStorage.getItem('throwawayWallet')?.includes(':');
+
       const storedWallet = localStorage.getItem('throwawayWallet')?.split(':')[1];
       const lastConnectedAddress = localStorage.getItem('throwawayWallet')?.split(':')[0];
       if (
@@ -128,7 +130,7 @@ export const ThrowawayProvider = ({ children }: { children: ReactNode }) => {
         setThrowawayBalance(await getEthBalance(addr));
         setThrowawayUsdcAllowance(await getUsdcAllowance(mainAddr as `0x${string}`, addr));
         setThrowawayAddr(addr);
-      } else if (mainAddr) {
+      } else if (mainAddr || isOldVersion) {
         getExistingThrowaway({
           variables: {
             tags: [


### PR DESCRIPTION
Handles scenarios where old version of throwaway wallet exists, and reuses it so it is not lost.